### PR TITLE
Move to conduit.3.0.0 (include cohttp updates)

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,4 @@
     (name yurt)
     (public_name yurt)
     (wrapped false)
-    (libraries dynlink str cohttp-lwt-unix ezjsonm lwt_log))
+    (libraries dynlink str cohttp-lwt-unix conduit-lwt-unix.tls ezjsonm lwt_log))

--- a/src/yurt.mli
+++ b/src/yurt.mli
@@ -121,12 +121,12 @@ module Server : sig
         host : string;
         port : int;
         mutable routes : (string * Route.route * endpoint) list;
-        mutable tls_config : Conduit_lwt_unix.server_tls_config option;
+        mutable tls_config : Tls.Config.server option;
         mutable logger : Lwt_log.logger;
     }
 
     (** Create a new server *)
-    val server : ?tls_config:Conduit_lwt_unix.server_tls_config ->
+    val server : ?tls_config:Tls.Config.server ->
                     ?logger:Lwt_log.logger -> string -> int -> server
 
     (** Create a new server from an existing configuration file *)
@@ -139,7 +139,7 @@ module Server : sig
     val log_fatal : server -> string -> string -> unit
 
     (** Configure TLS after the server has been created *)
-    val configure_tls : ?password:[`Password of bool -> string | `No_password] -> server -> string -> string -> server
+    val configure_tls : server -> string -> string -> server
 
     (** Respond with a stream *)
     val stream:
@@ -231,41 +231,41 @@ end
 (** [Client] contains functions for sending HTTP requests *)
 module Client : sig
     (** Send a GET request *)
-    val get : ?ctx:Cohttp_lwt_unix.Net.ctx ->
+    val get : ?resolvers:Conduit.resolvers ->
               ?headers:Header.t ->
               string -> (Response.t * string) Lwt.t
 
     (** Send a POST request *)
-    val post : ?ctx:Cohttp_lwt_unix.Net.ctx ->
+    val post : ?resolvers:Conduit.resolvers ->
                ?headers:Header.t ->
                ?body:Body.t ->
                string -> (Response.t * string) Lwt.t
 
     (** Send a POST request with form encoded data *)
-    val post_form : ?ctx:Cohttp_lwt_unix.Net.ctx ->
+    val post_form : ?resolvers:Conduit.resolvers ->
                ?headers:Header.t ->
                params:(string * string list) list ->
                string -> (Response.t * string) Lwt.t
 
     (** Send another type of request other than POST or GET *)
-    val request : ?ctx:Cohttp_lwt_unix.Net.ctx ->
+    val request : ?resolvers:Conduit.resolvers ->
                ?headers:Header.t ->
                ?body:Body.t ->
                Cohttp.Code.meth -> string -> (Response.t * string) Lwt.t
 
     (** Send a get request and return JSON response *)
-    val get_json : ?ctx:Cohttp_lwt_unix.Net.ctx ->
+    val get_json : ?resolvers:Conduit.resolvers ->
               ?headers:Header.t ->
               string -> (Response.t * Ezjsonm.t) Lwt.t
 
     (** Send a post request and return JSON response *)
-    val post_json : ?ctx:Cohttp_lwt_unix.Net.ctx ->
+    val post_json : ?resolvers:Conduit.resolvers ->
                ?headers:Header.t ->
                ?body:Body.t ->
                string -> (Response.t * Ezjsonm.t) Lwt.t
 
     (** Send a POST request with from encoded data and return JSON response *)
-    val post_form_json : ?ctx:Cohttp_lwt_unix.Net.ctx ->
+    val post_form_json : ?resolvers:Conduit.resolvers ->
                ?headers:Header.t ->
                ?params:(string * string list) list ->
                string -> (Response.t * Ezjsonm.t) Lwt.t

--- a/src/yurt_client.ml
+++ b/src/yurt_client.ml
@@ -1,35 +1,35 @@
 open Lwt.Infix
 open Cohttp_lwt_unix
 
-let get ?ctx ?headers url =
-    Client.get ?ctx ?headers (Uri.of_string url) >>= fun (res, body) ->
+let get ?resolvers ?headers url =
+    Client.get ?resolvers ?headers (Uri.of_string url) >>= fun (res, body) ->
         Cohttp_lwt.Body.to_string body >|= fun body_string ->
             res, body_string
 
-let post ?ctx ?headers ?body url =
-    Client.post ?ctx ?headers ?body (Uri.of_string url) >>= fun (res, body) ->
+let post ?resolvers ?headers ?body url =
+    Client.post ?resolvers ?headers ?body (Uri.of_string url) >>= fun (res, body) ->
         Cohttp_lwt.Body.to_string body >|= fun body_string ->
             res, body_string
 
-let post_form ?ctx ?headers ~params url =
-    Client.post_form ?ctx ?headers ~params (Uri.of_string url) >>= fun (res, body) ->
+let post_form ?resolvers ?headers ~params url =
+    Client.post_form ?resolvers ?headers ~params (Uri.of_string url) >>= fun (res, body) ->
         Cohttp_lwt.Body.to_string body >|= fun body_string ->
             res, body_string
 
-let request ?ctx ?headers ?body meth url =
-    Client.call ?ctx ?headers ?body meth (Uri.of_string url) >>= fun (res, body) ->
+let request ?resolvers ?headers ?body meth url =
+    Client.call ?resolvers ?headers ?body meth (Uri.of_string url) >>= fun (res, body) ->
         Cohttp_lwt.Body.to_string body >|= fun body_string ->
             res, body_string
 
-let get_json ?ctx ?headers url =
-    get ?ctx ?headers url >|= fun (r, b) ->
+let get_json ?resolvers ?headers url =
+    get ?resolvers ?headers url >|= fun (r, b) ->
         r, Ezjsonm.from_string b
 
-let post_json ?ctx ?headers ?body url =
-    post ?ctx ?headers ?body url >|= fun (r, b) ->
+let post_json ?resolvers ?headers ?body url =
+    post ?resolvers ?headers ?body url >|= fun (r, b) ->
         r, Ezjsonm.from_string b
 
-let post_form_json ?ctx ?headers ?params:(params=[]) url =
-    post_form ?ctx ?headers ~params url >|= fun (r, b) ->
+let post_form_json ?resolvers ?headers ?params:(params=[]) url =
+    post_form ?resolvers ?headers ~params url >|= fun (r, b) ->
         r, Ezjsonm.from_string b
 


### PR DESCRIPTION
Stupid patch to use `conduit.3.0.0`, see mirage/ocaml-conduit#311.